### PR TITLE
fix(style): remove from-transparent in gradient

### DIFF
--- a/components/nav/nav-bottom.tsx
+++ b/components/nav/nav-bottom.tsx
@@ -34,7 +34,7 @@ export default function NavBottom(): JSX.Element {
       )}
 
       <div className="w-full pl-2.5 laptop:w-80 laptop:p-0 laptop:transition-width laptop:duration-300 laptop:ease-out laptop:absolute laptop:right-0 laptop:focus-within:w-11/12">
-        <div className="hidden absolute w-24 h-full -translate-x-full bg-gradient-to-r from-transparent to-white laptop:block"></div>
+        <div className="hidden absolute w-24 h-full -translate-x-full bg-gradient-to-r to-white laptop:block"></div>
         <Autocomplete placeholders={placeholders} />
       </div>
     </div>


### PR DESCRIPTION
this looks bad in Safari because transparent is rgba(0,0,0,0) instead of rgb(*insert color*, 0) and makes gradients look bad otherwise

some docs on this on tailwind's site: https://tailwindcss.com/docs/gradient-color-stops#fading-to-transparent