### PR TITLE
feat: add query rule redirects

### DIFF
--- a/components/@instantsearch/search.tsx
+++ b/components/@instantsearch/search.tsx
@@ -3,6 +3,7 @@ import isEqual from 'react-fast-compare'
 import type { InstantSearchProps } from 'react-instantsearch-dom'
 import { Configure, InstantSearch } from 'react-instantsearch-dom'
 
+import { QueryRuleRedirect } from '@instantsearch/widgets/query-rule-redirect/query-rule-redirect'
 import { VirtualSearchBox } from '@instantsearch/widgets/virtual-search-box/virtual-search-box'
 import { VirtualStateResults } from '@instantsearch/widgets/virtual-state-results/virtual-state-results'
 import { VirtualStats } from '@instantsearch/widgets/virtual-stats/virtual-stats'
@@ -24,6 +25,8 @@ function SearchComponent({
       <VirtualSearchBox />
       <VirtualStateResults />
       <VirtualStats />
+
+      <QueryRuleRedirect />
 
       {children}
     </InstantSearch>

--- a/components/@instantsearch/widgets/query-rule-redirect/query-rule-redirect.tsx
+++ b/components/@instantsearch/widgets/query-rule-redirect/query-rule-redirect.tsx
@@ -1,0 +1,20 @@
+import { memo } from 'react'
+import isEqual from 'react-fast-compare'
+import type { QueryRuleCustomDataProvided } from 'react-instantsearch-core'
+import { connectQueryRules } from 'react-instantsearch-dom'
+
+function QueryRuleRedirectComponent({ items }: QueryRuleCustomDataProvided) {
+  /*
+    The rule has to return custom data in the following format:
+    {
+      "redirect": "<URL>"
+    }
+  */
+  const match = items.find((data: any) => Boolean(data.redirect))
+  if (match?.redirect) window.location.href = match.redirect
+  return null
+}
+
+export const QueryRuleRedirect = connectQueryRules(
+  memo(QueryRuleRedirectComponent, isEqual)
+)


### PR DESCRIPTION
This PR adds rule redirections with the `connectQueryRules` connector.

In order to work, a manual rule must have a specific trigger (e.g. "query is algolia") and return query parameters in the following format:
```json
{
  "redirect": "<URL>"
}