### PR TITLE
feat: add analytics tags from user agent

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -3,6 +3,7 @@ import { freezeAtom } from 'jotai/utils'
 
 import type { SetUserToken } from '@/hooks/useSearchInsights'
 import type { Refinement, RefinementLayout } from '@/typings/refinements'
+import { userAnalyticsTags } from '@/utils/analyticsTags'
 import { capitalize } from '@/utils/capitalize'
 import { indexName } from '@/utils/env'
 
@@ -96,6 +97,7 @@ const searchParameters = {
   snippetEllipsisText: '…',
   analytics: true,
   clickAnalytics: true,
+  analyticsTags: userAnalyticsTags,
 }
 
 const setUserToken: SetUserToken = (generatedUserToken, setToken) => {

--- a/hooks/useSearchClient.ts
+++ b/hooks/useSearchClient.ts
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 
 // eslint-disable-next-line import/extensions
 import packageJson from '@/package.json'
+import { userAnalyticsTags } from '@/utils/analyticsTags'
 import { querySuggestionsIndexName } from '@/utils/env'
 
 export type SearchClientHookOptions = {
@@ -22,8 +23,12 @@ export function getSearchClient(
     ...client,
     search(requests) {
       const modifiedRequests = requests.map((searchParameters) => {
+        const { analyticsTags = [], ...requestParams } =
+          searchParameters.params || {}
+
         const detachedSearchParams = {
-          ...searchParameters.params,
+          ...requestParams,
+          analyticsTags: [...userAnalyticsTags, ...analyticsTags],
           page: 0,
           facetFilters: [],
           numericFilters: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pwa-ecom-ui-template",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pwa-ecom-ui-template",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@algolia/autocomplete-js": "^1.7.1",
@@ -18,6 +18,7 @@
         "@algolia/react-instantsearch-widget-loadmore-with-progressbar": "^1.4.0",
         "@algolia/react-instantsearch-widget-size-refinement-list": "^1.0.3",
         "@material-design-icons/svg": "^0.11.4",
+        "@types/ua-parser-js": "^0.7.36",
         "algoliasearch": "^4.13.1",
         "classnames": "^2.3.1",
         "framer-motion": "^6.4.2",
@@ -30,7 +31,8 @@
         "react-instantsearch-core": "^6.30.0",
         "react-instantsearch-dom": "^6.30.0",
         "react-responsive": "^9.0.0-beta.10",
-        "search-insights": "^2.2.1"
+        "search-insights": "^2.2.1",
+        "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
         "@netlify/plugin-nextjs": "^4.11.1",
@@ -3523,6 +3525,11 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
+    },
+    "node_modules/@types/ua-parser-js": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.32.0",
@@ -11588,6 +11595,24 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ufo": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-0.8.4.tgz",
@@ -15022,6 +15047,11 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
       "dev": true
+    },
+    "@types/ua-parser-js": {
+      "version": "0.7.36",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.36.tgz",
+      "integrity": "sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ=="
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.32.0",
@@ -20948,6 +20978,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
+    },
+    "ua-parser-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.2.tgz",
+      "integrity": "sha512-00y/AXhx0/SsnI51fTc0rLRmafiGOM4/O+ny10Ps7f+j/b8p/ZY11ytMgznXkOVo4GQ+KwQG5UQLkLGirsACRg=="
     },
     "ufo": {
       "version": "0.8.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@algolia/react-instantsearch-widget-loadmore-with-progressbar": "^1.4.0",
     "@algolia/react-instantsearch-widget-size-refinement-list": "^1.0.3",
     "@material-design-icons/svg": "^0.11.4",
+    "@types/ua-parser-js": "^0.7.36",
     "algoliasearch": "^4.13.1",
     "classnames": "^2.3.1",
     "framer-motion": "^6.4.2",
@@ -34,7 +35,8 @@
     "react-instantsearch-core": "^6.30.0",
     "react-instantsearch-dom": "^6.30.0",
     "react-responsive": "^9.0.0-beta.10",
-    "search-insights": "^2.2.1"
+    "search-insights": "^2.2.1",
+    "ua-parser-js": "^1.0.2"
   },
   "devDependencies": {
     "@netlify/plugin-nextjs": "^4.11.1",

--- a/utils/analyticsTags.ts
+++ b/utils/analyticsTags.ts
@@ -1,0 +1,45 @@
+import type { IDevice, IOS } from 'ua-parser-js'
+import parseUserAgent from 'ua-parser-js'
+
+// Map the most common devices from the OS in case the device is unknown
+const OSDevices: {
+  [key: string]: Omit<IDevice, 'vendor'>
+} = {
+  Android: {
+    model: 'unknown',
+    type: 'mobile',
+  },
+  iOS: {
+    model: 'Apple iPhone',
+    type: 'mobile',
+  },
+  'Mac OS': {
+    model: 'Apple Mac',
+    type: 'desktop',
+  },
+  Windows: {
+    model: 'unknown',
+    type: 'desktop',
+  },
+}
+
+const getUserDevice = (device: IDevice, os: IOS): Omit<IDevice, 'vendor'> => {
+  if (Object.keys(device).every((key) => Boolean(device[key as keyof IDevice])))
+    return { model: `${device.vendor} ${device.model}`, type: device.type }
+
+  return os.name ? OSDevices[os.name] : { model: 'unknown', type: 'unknown' }
+}
+
+const getUserAnalyticsTags = (): string[] => {
+  const { browser, device, os } = parseUserAgent()
+  const { model, type } = getUserDevice(device, os)
+
+  return [
+    `browser:${browser.name || 'unknown'}`,
+    `device:${model}`,
+    `deviceType:${type}`,
+    `os:${os.name || 'unknown'}`,
+  ]
+}
+
+export const userAnalyticsTags = getUserAnalyticsTags()


### PR DESCRIPTION
This PR adds some user-related analytics tags to each request by parsing the user agent string with [ua-parser-js](https://github.com/faisalman/ua-parser-js) and building the corresponding tags. 

The tags are related to the user browser, OS, and device model and type. This is a typical payload including the `analyticsTags` parameter:
```js
{
  // ...other params

  "analyticsTags": [
    "browser:Chrome", 
    "device:Apple Mac", 
    "deviceType:desktop", 
    "os:Mac OS"
  ]
}
```